### PR TITLE
docs: add local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Como rodar o sistema localmente
+
+Este repositório contém uma aplicação [Laravel](https://laravel.com) com frontend em React e Vite.
+
+## Pré-requisitos
+- PHP 8.2+
+- [Composer](https://getcomposer.org/)
+- Node.js e npm
+
+## Passo a passo
+1. Entre na pasta do projeto e acesse o diretório `src`:
+   ```bash
+   cd src
+   ```
+2. Copie o arquivo de exemplo de ambiente:
+   ```bash
+   cp .env.example .env
+   ```
+3. Instale as dependências do PHP e do Node:
+   ```bash
+   composer install
+   npm install
+   ```
+4. Gere a chave da aplicação e execute as migrações:
+   ```bash
+   php artisan key:generate
+   php artisan migrate
+   ```
+
+## Executando
+Para iniciar o servidor de desenvolvimento, execute:
+```bash
+composer run dev
+```
+
+O sistema ficará disponível em [http://localhost:8000](http://localhost:8000).


### PR DESCRIPTION
## Summary
- add README with instructions to run the application locally

## Testing
- `composer test` *(fails: missing vendor/autoload.php; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f965ae0832c8209ea1c6f7106b5