### PR TITLE
chore: switch MySQL port to 3307

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Este repositório contém uma aplicação [Laravel](https://laravel.com) com fro
    docker compose up --build
    ```
 
-O aplicativo estará disponível em [http://localhost:8000](http://localhost:8000) e o phpMyAdmin em [http://localhost:8080](http://localhost:8080). O banco de dados MySQL ficará disponível na porta `3306` com o usuário `laravel` e senha `secret`.
+O aplicativo estará disponível em [http://localhost:8000](http://localhost:8000) e o phpMyAdmin em [http://localhost:8080](http://localhost:8080). O banco de dados MySQL ficará disponível na porta `3307` com o usuário `laravel` e senha `secret`.
 
 ## Rodando localmente sem Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       MYSQL_PASSWORD: secret
       MYSQL_ROOT_PASSWORD: root
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - db_data:/var/lib/mysql
 


### PR DESCRIPTION
## Summary
- avoid host port conflicts by exposing MySQL on 3307
- document new port in README

## Testing
- `composer test` *(fails: require(/workspace/project-a/src/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68bc427ed8d4832c81cd7f7ba0db9387