### PR TITLE
feat: adicionar seeder de usuários por cargo

### DIFF
--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,13 +11,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        $this->call(RoleSeeder::class);
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            RoleSeeder::class,
+            UserSeeder::class,
         ]);
     }
 }

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Seed the application's users.
+     */
+    public function run(): void
+    {
+        $users = [
+            [
+                'name' => 'Manager',
+                'email' => 'manager@example.com',
+                'role' => 'manager',
+            ],
+            [
+                'name' => 'Operator',
+                'email' => 'operator@example.com',
+                'role' => 'operator',
+            ],
+            [
+                'name' => 'Customer',
+                'email' => 'customer@example.com',
+                'role' => 'customer',
+            ],
+        ];
+
+        foreach ($users as $data) {
+            $user = User::firstOrCreate(
+                ['email' => $data['email']],
+                [
+                    'name' => $data['name'],
+                    'password' => 'password',
+                ]
+            );
+
+            $role = Role::where('name', $data['role'])->first();
+            if ($role) {
+                $user->roles()->syncWithoutDetaching([$role->id]);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- cria UserSeeder com três usuários e respectivos cargos
- ajusta DatabaseSeeder para executar RoleSeeder e UserSeeder

## Testing
- `composer test` *(falhou: Missing vendor/autoload.php)*
- `composer install` *(falhou: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc87a51de4832c8422694b9f4d9e8e